### PR TITLE
fix handling of multiple feature files

### DIFF
--- a/cucumber-plugin/src/main/scala/com/waioeka/sbt/CucumberParameters.scala
+++ b/cucumber-plugin/src/main/scala/com/waioeka/sbt/CucumberParameters.scala
@@ -69,14 +69,12 @@ case class CucumberParameters(
     * @return a list of string parameters.
     */
   def toList : List[String] = {
-    val featureOpts = features mkString " "
-
     boolToParameter(dryRun,"dry-run") :::
       boolToParameter(monochrome,"monochrome") :::
       List("--glue",s"$glue") :::
       plugins.map(_.toCucumberPlugin).flatMap(plugin => Seq("--plugin", plugin)) :::
       additionalArgs :::
-      List(s"$featureOpts")
+      features
   }
 
 }


### PR DESCRIPTION
Previously, the paths to all feature files were concatenated into
one command line argument to cucumber. Which then failed to parse that.