### PR TITLE
Re-add default setting for 'monochrome'

### DIFF
--- a/cucumber-plugin/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
+++ b/cucumber-plugin/src/main/scala/com/waioeka/sbt/CucumberPlugin.scala
@@ -116,6 +116,7 @@ object CucumberPlugin extends AutoPlugin {
     mainClass := "cucumber.api.cli.Main",
     dryRun := false,
     features := List("classpath:"),
+    monochrome := false,
     cucumberTestReports := new File(new File(target.value, "test-reports"), "cucumber"),
     systemProperties := Map(),
     plugin := {


### PR DESCRIPTION
The default setting was removed with
https://github.com/lewismj/cucumber/commit/edbcc4845357eef4a331705c9bc5cb0ec5570107
but no update to README.md