### PR TITLE
sbt 1.0/0.13 crossbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: scala
-
-scala:
-  - 2.10.6
+matrix:
+  include:
+  - env: SBT_VERSION="0.13.16"
+    scala: 2.10.6
+  - env: SBT_VERSION="1.0.2"
+    scala: 2.12.3
 
 script:
   - ./.travis.sh

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 name := "cucumber-runner"
-organization  := "com.waioeka.sbt"
+organization := "com.waioeka.sbt"
 scalaVersion := "2.12.3"
 version := "0.1.3"
 
@@ -11,12 +11,12 @@ publishTo := Some(
 )
 
 
-libraryDependencies ++= Seq (
-   	"io.cucumber" % "cucumber-core" % "2.0.0",
-  	"io.cucumber" %% "cucumber-scala" % "2.0.0",
-       	"io.cucumber" % "cucumber-jvm" % "2.0.0",
-       	"io.cucumber" % "cucumber-junit" % "2.0.0",
-       	"org.scala-sbt" % "test-interface" % "1.0")
+libraryDependencies ++= Seq(
+  "io.cucumber" % "cucumber-core" % "2.0.1",
+  "io.cucumber" %% "cucumber-scala" % "2.0.1",
+  "io.cucumber" % "cucumber-jvm" % "2.0.1",
+  "io.cucumber" % "cucumber-junit" % "2.0.1",
+  "org.scala-sbt" % "test-interface" % "1.0")
 
 
 pomIncludeRepository := Function.const(false)

--- a/plugin/cucumber-plugin/build.sbt
+++ b/plugin/cucumber-plugin/build.sbt
@@ -6,12 +6,16 @@ sbtPlugin := true
 
 version := "0.1.6"
 
+sbtVersion in Global := "1.0.2"
+crossSbtVersions := Seq("1.0.2", "0.13.16")
+scalacOptions += "-target:jvm-1.8"
+
 
 libraryDependencies ++= Seq (
-	"io.cucumber" % "cucumber-core" % "2.0.0",
-	"io.cucumber" %% "cucumber-scala" % "2.0.0",
-	"io.cucumber" % "cucumber-jvm" % "2.0.0" artifacts Artifact("cucumber-jvm", `type`="pom", extension="pom"),
-	"io.cucumber" % "cucumber-junit" % "2.0.0",
+	"io.cucumber" % "cucumber-core" % "2.0.1",
+	"io.cucumber" %% "cucumber-scala" % "2.0.1",
+	"io.cucumber" % "cucumber-jvm" % "2.0.1" artifacts Artifact("cucumber-jvm", `type`="pom", extension="pom"),
+	"io.cucumber" % "cucumber-junit" % "2.0.1",
 	"org.apache.commons" % "commons-lang3" % "3.5")
 
 

--- a/plugin/cucumber-plugin/project/build.properties
+++ b/plugin/cucumber-plugin/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.0.2


### PR DESCRIPTION
Attempt to crossbuild the plugin for sbt 1.0/0.13
Not quite sure about the travis.yaml though. Since it was just using scala 2.10 i figured it's only used for the plugin, but since this project is more than just an sbt plugin, i'm not totally sure.